### PR TITLE
GPT3 upgraded to gpt-3.5-turbo-instruct from text-davinci-003

### DIFF
--- a/engine/utils.py
+++ b/engine/utils.py
@@ -72,7 +72,7 @@ class ProgramGenerator():
 
     def generate(self,inputs):
         response = openai.Completion.create(
-            model="text-davinci-003",
+            model="gpt-3.5-turbo-instruct",
             prompt=self.prompter(inputs),
             temperature=self.temperature,
             max_tokens=512,


### PR DESCRIPTION
Hello!
On January 4, 2024, text-davinci-003 ended support.
It looks like we need to change to gpt-3.5-turbo-instruct.
Thank you so much for the good code.