### PR TITLE
Update environment.yaml to include missing pip package

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -15,3 +15,4 @@ dependencies:
     - diffusers==0.14.0
     - accelerate==0.17.1
     - ipykernel==6.15.2
+    - chardet==5.2.0


### PR DESCRIPTION
a package dependency is missing which fails to run the jupyter notebook for image_editing